### PR TITLE
Added pre/post persist comment event

### DIFF
--- a/Controller/WebsiteCommentController.php
+++ b/Controller/WebsiteCommentController.php
@@ -73,6 +73,7 @@ class WebsiteCommentController extends RestController implements ClassResourceIn
             return new Response(null, 400);
         }
 
+        // invalidate cache for thread-comments.
         $this->get('sulu_http_cache.handler.url')->invalidatePath(
             $this->generateUrl('get_threads_comments', ['threadId' => $threadId, '_format' => 'html'])
         );
@@ -82,6 +83,7 @@ class WebsiteCommentController extends RestController implements ClassResourceIn
 
         list($type, $entityId) = $this->getThreadIdParts($threadId);
 
+        // deserialize comment
         $serializer = $this->get('serializer');
         $comment = $serializer->deserialize(
             json_encode($data),
@@ -93,9 +95,7 @@ class WebsiteCommentController extends RestController implements ClassResourceIn
         $thread = $commentManager->addComment($type, $entityId, $comment);
         $thread->setTitle($request->get('threadTitle'));
 
-        $entityManager = $this->get('doctrine.orm.entity_manager');
-        $entityManager->persist($thread);
-        $entityManager->flush();
+        $this->get('doctrine.orm.entity_manager')->flush();
 
         if ($request->getRequestFormat() === 'json') {
             return $this->handleView($this->view($comment));

--- a/Entity/CommentRepository.php
+++ b/Entity/CommentRepository.php
@@ -40,4 +40,14 @@ class CommentRepository extends EntityRepository implements CommentRepositoryInt
 
         return $query->getResult();
     }
+
+    /**
+     * Persists comment.
+     *
+     * @param CommentInterface $comment
+     */
+    public function persist(CommentInterface $comment)
+    {
+        $this->getEntityManager()->persist($comment);
+    }
 }

--- a/Entity/CommentRepositoryInterface.php
+++ b/Entity/CommentRepositoryInterface.php
@@ -11,10 +11,12 @@
 
 namespace Sulu\Bundle\CommentBundle\Entity;
 
+use Sulu\Component\Persistence\Repository\RepositoryInterface;
+
 /**
  * Interface for comment-repository.
  */
-interface CommentRepositoryInterface
+interface CommentRepositoryInterface extends RepositoryInterface
 {
     /**
      * Returns comments for given thread.
@@ -27,4 +29,11 @@ interface CommentRepositoryInterface
      * @return Comment[]
      */
     public function findComments($type, $entityId, $page = 1, $pageSize = null);
+
+    /**
+     * Persists comment.
+     *
+     * @param CommentInterface $comment
+     */
+    public function persist(CommentInterface $comment);
 }

--- a/Entity/ThreadRepository.php
+++ b/Entity/ThreadRepository.php
@@ -25,7 +25,10 @@ class ThreadRepository extends EntityRepository implements ThreadRepositoryInter
     {
         $className = $this->getClassName();
 
-        return new $className($type, $entityId);
+        $thread = new $className($type, $entityId);
+        $this->getEntityManager()->persist($thread);
+
+        return $thread;
     }
 
     /**

--- a/Events/CommentEvent.php
+++ b/Events/CommentEvent.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CommentBundle\Events;
+
+use Sulu\Bundle\CommentBundle\Entity\CommentInterface;
+use Sulu\Bundle\CommentBundle\Entity\ThreadInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event-arguments for pre and post persist event.
+ */
+class CommentEvent extends Event
+{
+    /**
+     * @var CommentInterface
+     */
+    private $comment;
+
+    /**
+     * @var ThreadInterface
+     */
+    private $thread;
+
+    /**
+     * @param CommentInterface $comment
+     * @param ThreadInterface $thread
+     */
+    public function __construct(CommentInterface $comment, ThreadInterface $thread)
+    {
+        $this->comment = $comment;
+        $this->thread = $thread;
+    }
+
+    /**
+     * Returns comment.
+     *
+     * @return CommentInterface
+     */
+    public function getComment()
+    {
+        return $this->comment;
+    }
+
+    /**
+     * Returns thread.
+     *
+     * @return ThreadInterface
+     */
+    public function getThread()
+    {
+        return $this->thread;
+    }
+}

--- a/Events/Events.php
+++ b/Events/Events.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CommentBundle\Events;
+
+/**
+ * Container for comment-events.
+ */
+final class Events
+{
+    const PRE_PERSIST_EVENT = 'sulu_comment.pre_persist';
+    const POST_PERSIST_EVENT = 'sulu_comment.post_persist';
+
+    /**
+     * Private constructor.
+     */
+    private function __construct()
+    {
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -15,6 +15,7 @@
         <service id="sulu_comment.manager" class="Sulu\Bundle\CommentBundle\Manager\CommentManager">
             <argument type="service" id="sulu.repository.thread"/>
             <argument type="service" id="sulu.repository.comment"/>
+            <argument type="service" id="event_dispatcher"/>
         </service>
     </services>
 </container>

--- a/Tests/Unit/Manager/CommentManagerTest.php
+++ b/Tests/Unit/Manager/CommentManagerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CommentBundle\Tests\Unit\Manager;
+
+use Prophecy\Argument;
+use Sulu\Bundle\CommentBundle\Entity\CommentInterface;
+use Sulu\Bundle\CommentBundle\Entity\CommentRepositoryInterface;
+use Sulu\Bundle\CommentBundle\Entity\ThreadInterface;
+use Sulu\Bundle\CommentBundle\Entity\ThreadRepositoryInterface;
+use Sulu\Bundle\CommentBundle\Events\CommentEvent;
+use Sulu\Bundle\CommentBundle\Events\Events;
+use Sulu\Bundle\CommentBundle\Manager\CommentManager;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class CommentManagerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ThreadRepositoryInterface
+     */
+    private $threadRepository;
+
+    /**
+     * @var CommentRepositoryInterface
+     */
+    private $commentRepository;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $dispatcher;
+
+    /**
+     * @var CommentManager
+     */
+    private $commentManager;
+
+    /**
+     * @var ThreadInterface
+     */
+    private $thread;
+
+    /**
+     * @var CommentInterface
+     */
+    private $comment;
+
+    protected function setUp()
+    {
+        $this->threadRepository = $this->prophesize(ThreadRepositoryInterface::class);
+        $this->commentRepository = $this->prophesize(CommentRepositoryInterface::class);
+        $this->dispatcher = $this->prophesize(EventDispatcherInterface::class);
+
+        $this->thread = $this->prophesize(ThreadInterface::class);
+        $this->comment = $this->prophesize(CommentInterface::class);
+
+        $this->commentManager = new CommentManager(
+            $this->threadRepository->reveal(),
+            $this->commentRepository->reveal(),
+            $this->dispatcher->reveal()
+        );
+    }
+
+    public function testFindComments($type = 'article', $entityId = '123-123-123')
+    {
+        $this->commentRepository->findComments($type, $entityId, 1, null)->shouldBeCalled()->willReturn([]);
+
+        $comments = $this->commentManager->findComments($type, $entityId);
+        $this->assertEquals([], $comments);
+    }
+
+    public function testAddComment($type = 'article', $entityId = '123-123-123')
+    {
+        $this->threadRepository->findThread($type, $entityId)->willReturn($this->thread->reveal());
+
+        $commentRepository = $this->commentRepository;
+        $comment = $this->comment;
+        $dispatcher = $this->dispatcher;
+        $thread = $this->thread;
+
+        $this->dispatcher->dispatch(Events::PRE_PERSIST_EVENT, Argument::type(CommentEvent::class))
+            ->shouldBeCalledTimes(1)
+            ->will(
+                function () use ($commentRepository, $comment, $dispatcher, $thread) {
+                    $thread->addComment($comment->reveal())->willReturn($thread->reveal());
+                    $commentRepository->persist($comment->reveal())
+                        ->shouldBeCalledTimes(1)
+                        ->will(
+                            function () use ($dispatcher, $thread) {
+                                $dispatcher->dispatch(
+                                    Events::POST_PERSIST_EVENT,
+                                    Argument::type(CommentEvent::class)
+                                )->shouldBeCalledTimes(1);
+
+                                return $thread->reveal();
+                            }
+                        );
+                }
+            );
+
+        $thread = $this->commentManager->addComment($type, $entityId, $this->comment->reveal());
+
+        $this->assertEquals($this->thread->reveal(), $thread);
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR adds the events pre/post persist for comments

#### Why?

This can be used to determine comment-counts for other entities or set different data then the standard is able to.

#### To Do

- [x] Tests

