### PR TITLE
add filter for thread and comment rest api

### DIFF
--- a/Controller/CommentController.php
+++ b/Controller/CommentController.php
@@ -57,7 +57,14 @@ class CommentController extends RestController implements ClassResourceInterface
         $factory = $this->get('sulu_core.doctrine_list_builder_factory');
         $listBuilder = $factory->create($this->getParameter('sulu.model.comment.class'));
 
-        $restHelper->initializeListBuilder($listBuilder, $this->getFieldDescriptors());
+        $fieldDescriptors = $this->getFieldDescriptors();
+        $restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
+
+        foreach ($request->query->all() as $filterKey => $filterValue) {
+            if (isset($fieldDescriptors[$filterKey])) {
+                $listBuilder->where($fieldDescriptors[$filterKey], $filterValue);
+            }
+        }
 
         $results = $listBuilder->execute();
         $list = new ListRepresentation(

--- a/Controller/ThreadController.php
+++ b/Controller/ThreadController.php
@@ -57,6 +57,12 @@ class ThreadController extends RestController implements ClassResourceInterface
         $fieldDescriptors = $this->getFieldDescriptors();
         $restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
 
+        foreach ($request->query->all() as $filterKey => $filterValue) {
+            if (isset($fieldDescriptors[$filterKey])) {
+                $listBuilder->where($fieldDescriptors[$filterKey], $filterValue);
+            }
+        }
+
         $typeParameter = $request->get('types');
         if ($typeParameter) {
             $listBuilder->in($fieldDescriptors['type'], array_filter(explode(',', $typeParameter)));

--- a/Tests/Functional/Controller/CommentControllerTest.php
+++ b/Tests/Functional/Controller/CommentControllerTest.php
@@ -50,6 +50,43 @@ class CommentControllerTest extends SuluTestCase
         $this->assertEquals($comment->getMessage(), $data['message']);
     }
 
+    public function testCGet()
+    {
+        $thread = $this->createThread();
+        $this->createComment($thread);
+        $this->createComment($thread);
+        $this->createComment($thread);
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', '/api/comments');
+
+        $this->assertHttpStatusCode(200, $client->getResponse());
+        $data = json_decode($client->getResponse()->getContent(), true);
+
+        $this->assertCount(3, $data['_embedded']['comments']);
+    }
+
+    public function testCGetFilter()
+    {
+        $thread = $this->createThread();
+        $this->createComment($thread);
+        $this->createComment($thread, 'Message', CommentInterface::STATE_UNPUBLISHED);
+        $this->createComment($thread);
+
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', '/api/comments?state=' . CommentInterface::STATE_UNPUBLISHED);
+
+        $this->assertHttpStatusCode(200, $client->getResponse());
+        $data = json_decode($client->getResponse()->getContent(), true);
+
+        $this->assertCount(1, $data['_embedded']['comments']);
+    }
+
     public function testPut()
     {
         $thread = $this->createThread();

--- a/Tests/Functional/Controller/ThreadControllerTest.php
+++ b/Tests/Functional/Controller/ThreadControllerTest.php
@@ -47,6 +47,24 @@ class ThreadControllerTest extends SuluTestCase
         $this->assertEquals($thread->getTitle(), $data['title']);
     }
 
+    public function testCGetFilter()
+    {
+        $this->createThread('Test 1', 'page', 'Test 1');
+        $this->createThread('Test 2', 'page', 'Test 2');
+        $this->createThread('Test 3', 'article', 'Test 3');
+
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', '/api/threads?type=page');
+
+        $this->assertHttpStatusCode(200, $client->getResponse());
+        $data = json_decode($client->getResponse()->getContent(), true);
+
+        $this->assertCount(2, $data['_embedded']['threads']);
+    }
+
     public function testPut()
     {
         $thread = $this->createThread();

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "sulu/document-manager": "@dev",
         "massive/search-bundle": "@dev",
         "symfony/monolog-bundle": "2.4.*",
-        "phpunit/phpunit": ">=4.8"
+        "phpunit/phpunit": ">=4.8, <6.0"
     },
     "keywords": [],
     "authors": [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add filter for thread and comment rest api

#### Why?

Make filter able list presentations.

#### Example Usage

/admin/api/comments?creatorId=2
/admin/api/threads?creatorId=2
