### PR TITLE
Fixed set-title before comment-events

### DIFF
--- a/Controller/WebsiteCommentController.php
+++ b/Controller/WebsiteCommentController.php
@@ -97,8 +97,7 @@ class WebsiteCommentController extends RestController implements ClassResourceIn
         );
 
         $commentManager = $this->get('sulu_comment.manager');
-        $thread = $commentManager->addComment($type, $entityId, $comment);
-        $thread->setTitle($request->get('threadTitle'));
+        $commentManager->addComment($type, $entityId, $comment, $request->get('threadTitle'));
 
         $this->get('doctrine.orm.entity_manager')->flush();
 

--- a/Manager/CommentManager.php
+++ b/Manager/CommentManager.php
@@ -74,11 +74,15 @@ class CommentManager implements CommentManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function addComment($type, $entityId, CommentInterface $comment)
+    public function addComment($type, $entityId, CommentInterface $comment, $threadTitle = null)
     {
         $thread = $this->threadRepository->findThread($type, $entityId);
         if (!$thread) {
             $thread = $this->threadRepository->createNew($type, $entityId);
+        }
+
+        if ($threadTitle) {
+            $thread->setTitle($threadTitle);
         }
 
         $this->dispatcher->dispatch(Events::PRE_PERSIST_EVENT, new CommentEvent($type, $entityId, $comment, $thread));

--- a/Manager/CommentManagerInterface.php
+++ b/Manager/CommentManagerInterface.php
@@ -49,10 +49,11 @@ interface CommentManagerInterface
      * @param string $type
      * @param string $entityId
      * @param CommentInterface $comment
+     * @param string $threadTitle
      *
      * @return ThreadInterface
      */
-    public function addComment($type, $entityId, CommentInterface $comment);
+    public function addComment($type, $entityId, CommentInterface $comment, $threadTitle = null);
 
     /**
      * Update given comment.


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR set the title of thread before the comment events occurs.

#### Why?

If you use the thread in the listener the title will be empty for the first comment of a thread.