### PR TITLE
Use generic toggler with options to repace publish toggler

### DIFF
--- a/Admin/CommentAdmin.php
+++ b/Admin/CommentAdmin.php
@@ -17,6 +17,7 @@ use Sulu\Bundle\AdminBundle\Navigation\Navigation;
 use Sulu\Bundle\AdminBundle\Navigation\NavigationItem;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Integrates sulu_comment into sulu-admin.
@@ -43,10 +44,19 @@ class CommentAdmin extends Admin
      */
     private $securityChecker;
 
-    public function __construct(RouteBuilderFactoryInterface $routeBuilderFactory, SecurityCheckerInterface $securityChecker)
-    {
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(
+        RouteBuilderFactoryInterface $routeBuilderFactory,
+        SecurityCheckerInterface $securityChecker,
+        TranslatorInterface $translator
+    ) {
         $this->routeBuilderFactory = $routeBuilderFactory;
         $this->securityChecker = $securityChecker;
+        $this->translator = $translator;
     }
 
     public function getNavigation(): Navigation
@@ -87,6 +97,14 @@ class CommentAdmin extends Admin
             'sulu_admin.delete',
         ];
 
+        /** @var array $commentFormToolbarActions */
+        $commentFormToolbarActions = array_merge($formToolbarActions, ['sulu_admin.toggler' => [
+            'label' => $this->translator->trans('sulu_admin.publish', [], 'admin'),
+            'property' => 'published',
+            'activate' => 'publish',
+            'deactivate' => 'unpublish',
+        ]]);
+
         $listToolbarActions = [
             'sulu_admin.delete',
             'sulu_admin.export',
@@ -110,7 +128,7 @@ class CommentAdmin extends Admin
                 ->setResourceKey('comments')
                 ->setFormKey('comment_details')
                 ->setTabTitle('sulu_admin.details')
-                ->addToolbarActions(array_merge($formToolbarActions, ['sulu_admin.publish_toggler']))
+                ->addToolbarActions($commentFormToolbarActions)
                 ->setParent(static::COMMENT_EDIT_FORM_ROUTE)
                 ->getRoute(),
             $this->routeBuilderFactory->createListRouteBuilder(static::THREAD_LIST_ROUTE, '/threads')

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -7,6 +7,7 @@
         <service id="sulu_comment.admin" class="Sulu\Bundle\CommentBundle\Admin\CommentAdmin">
             <argument type="service" id="sulu_admin.route_factory"/>
             <argument type="service" id="sulu_security.security_checker"/>
+            <argument type="service" id="translator"/>
 
             <tag name="sulu.admin"/>
             <tag name="sulu.context" context="admin"/>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | https://github.com/sulu/sulu/pull/4674/files#diff-bdaebd5fa3c85c7c60b7966165fc5ca4R194
| License | MIT

#### What's in this PR?

This PR replaces removed publish_toggler with generic toggler.