### PR TITLE
Activate phpstan-strict-rules extension to force typehints

### DIFF
--- a/Controller/ThreadController.php
+++ b/Controller/ThreadController.php
@@ -71,7 +71,7 @@ class ThreadController extends RestController implements ClassResourceInterface
         return $this->handleView($this->view($thread));
     }
 
-    public function putAction($id, Request $request): Response
+    public function putAction(int $id, Request $request): Response
     {
         /** @var ThreadInterface|null $thread */
         $thread = $this->get('sulu.repository.thread')->findThreadById($id);

--- a/Controller/WebsiteCommentController.php
+++ b/Controller/WebsiteCommentController.php
@@ -137,7 +137,7 @@ class WebsiteCommentController extends RestController implements ClassResourceIn
     /**
      * Splits the thread-id into type and entity-id.
      *
-     * @return array list($type, $entityId)
+     * @return string[] list($type, $entityId)
      */
     private function getThreadIdParts(string $threadId): array
     {

--- a/Entity/Comment.php
+++ b/Entity/Comment.php
@@ -111,7 +111,7 @@ class Comment implements CommentInterface, AuditableInterface
         return $this->message ?? '';
     }
 
-    public function setMessage($message): CommentInterface
+    public function setMessage(string $message): CommentInterface
     {
         $this->message = $message;
 

--- a/Entity/CommentInterface.php
+++ b/Entity/CommentInterface.php
@@ -29,7 +29,7 @@ interface CommentInterface
 
     public function getMessage(): string;
 
-    public function setMessage($message): self;
+    public function setMessage(string $message): self;
 
     public function getThread(): ThreadInterface;
 

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "phpstan/phpstan-doctrine": "^0.11.5",
         "phpstan/phpstan-phpunit": "^0.11.2",
         "phpstan/phpstan-symfony": "^0.11.6",
+        "thecodingmachine/phpstan-strict-rules": "^0.11.2",
         "phpunit/phpunit": "^7.0",
         "sulu/document-manager": "@dev",
         "symfony/browser-kit": "^3.4 || ^4.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,7 @@ includes:
     - vendor/phpstan/phpstan-symfony/extension.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-phpunit/rules.neon
+    - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
 
 parameters:
     paths:


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR activates the phpstan-strict-rules extension. 