### PR TITLE
Replace deprecated Symfony TranslatorInterface

### DIFF
--- a/Admin/CommentAdmin.php
+++ b/Admin/CommentAdmin.php
@@ -20,7 +20,7 @@ use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Integrates sulu_comment into sulu-admin.


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | none
| Related issues/PRs | https://github.com/symfony/symfony/pull/38328
| License | MIT
| Documentation PR | none

#### What's in this PR?

Replace deprecated Symfony\Component\Translation\TranslatorInterface with Symfony\Contracts\Translation\TranslatorInterface
https://github.com/symfony/symfony/pull/38328