### PR TITLE
Fix pipeline by updating PHPStan

### DIFF
--- a/Admin/CommentAdmin.php
+++ b/Admin/CommentAdmin.php
@@ -96,7 +96,7 @@ class CommentAdmin extends Admin
             new ToolbarAction('sulu_admin.delete'),
         ];
 
-        /** @var array $commentFormToolbarActions */
+        /** @var array<TogglerToolbarAction> $commentFormToolbarActions */
         $commentFormToolbarActions = array_merge($formToolbarActions, [
             new TogglerToolbarAction(
                 $this->translator->trans('sulu_admin.publish', [], 'admin'),

--- a/Controller/CommentController.php
+++ b/Controller/CommentController.php
@@ -101,7 +101,7 @@ class CommentController extends AbstractRestController implements ClassResourceI
         $fieldDescriptors = $this->fieldDescriptorFactory->getFieldDescriptors('comments');
         $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
 
-        $threadType = $request->query->get('threadType', '');
+        $threadType = (string) $request->query->get('threadType', '');
         if ($threadType) {
             $listBuilder->in(
                 $fieldDescriptors['threadType'],

--- a/Controller/CommentController.php
+++ b/Controller/CommentController.php
@@ -149,7 +149,7 @@ class CommentController extends AbstractRestController implements ClassResourceI
             throw new EntityNotFoundException(CommentInterface::class, $id);
         }
 
-        $comment->setMessage($request->request->get('message'));
+        $comment->setMessage((string) $request->request->get('message'));
 
         $this->commentManager->update($comment);
         $this->entityManager->flush();

--- a/Controller/ThreadController.php
+++ b/Controller/ThreadController.php
@@ -139,7 +139,7 @@ class ThreadController extends AbstractRestController implements ClassResourceIn
             throw new EntityNotFoundException(ThreadInterface::class, $id);
         }
 
-        $thread->setTitle($request->request->get('title'));
+        $thread->setTitle((string) $request->request->get('title'));
 
         $this->commentManager->updateThread($thread);
         $this->entityManager->flush();

--- a/Controller/WebsiteCommentController.php
+++ b/Controller/WebsiteCommentController.php
@@ -200,7 +200,7 @@ class WebsiteCommentController extends AbstractRestController implements ClassRe
         $this->commentManager->addComment($type, $entityId, $comment, $request->get('threadTitle'));
         $this->entityManager->flush();
 
-        if ($referrer = $request->query->get('referrer')) {
+        if ($referrer = (string) $request->query->get('referrer')) {
             return new RedirectResponse($referrer);
         }
 
@@ -233,7 +233,7 @@ class WebsiteCommentController extends AbstractRestController implements ClassRe
         $comment->setMessage($message);
         $this->entityManager->flush();
 
-        if ($referrer = $request->query->get('referrer')) {
+        if ($referrer = (string) $request->query->get('referrer')) {
             return new RedirectResponse($referrer);
         }
 
@@ -260,7 +260,7 @@ class WebsiteCommentController extends AbstractRestController implements ClassRe
         $this->entityManager->remove($comment);
         $this->entityManager->flush();
 
-        if ($referrer = $request->query->get('referrer')) {
+        if ($referrer = (string) $request->query->get('referrer')) {
             return new RedirectResponse($referrer);
         }
 

--- a/Controller/WebsiteCommentController.php
+++ b/Controller/WebsiteCommentController.php
@@ -226,7 +226,7 @@ class WebsiteCommentController extends AbstractRestController implements ClassRe
     {
         list($type, $entityId) = $this->getThreadIdParts($threadId);
 
-        $message = $request->request->get('message');
+        $message = (string) $request->request->get('message');
 
         /** @var Comment $comment */
         $comment = $this->commentRepository->findCommentById((int) $commentId);

--- a/DependencyInjection/SuluCommentExtension.php
+++ b/DependencyInjection/SuluCommentExtension.php
@@ -28,7 +28,7 @@ class SuluCommentExtension extends Extension implements PrependExtensionInterfac
     /**
      * {@inheritdoc}
      */
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         if ($container->hasExtension('jms_serializer')) {
             $container->prependExtensionConfig(
@@ -82,7 +82,7 @@ class SuluCommentExtension extends Extension implements PrependExtensionInterfac
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);

--- a/Entity/Comment.php
+++ b/Entity/Comment.php
@@ -61,7 +61,7 @@ class Comment implements CommentInterface, AuditableInterface
     protected $parent;
 
     /**
-     * @var Collection|CommentInterface[]
+     * @var Collection<int, CommentInterface>
      */
     protected $children;
 

--- a/Entity/CommentInterface.php
+++ b/Entity/CommentInterface.php
@@ -43,8 +43,14 @@ interface CommentInterface
 
     public function getDepth(): int;
 
+    /**
+     * @return Collection<int, CommentInterface>
+     */
     public function getChildren(): Collection;
 
+    /**
+     * @return Collection<int, CommentInterface>
+     */
     public function getPublishedChildren(): Collection;
 
     public function getCreatorFullName(): string;

--- a/Entity/CommentRepository.php
+++ b/Entity/CommentRepository.php
@@ -100,6 +100,9 @@ class CommentRepository extends NestedTreeRepository implements CommentRepositor
         $this->getEntityManager()->remove($comment);
     }
 
+    /**
+     * @return CommentInterface
+     */
     public function createNew()
     {
         $className = $this->getClassName();

--- a/Entity/CommentRepositoryInterface.php
+++ b/Entity/CommentRepositoryInterface.php
@@ -13,6 +13,9 @@ namespace Sulu\Bundle\CommentBundle\Entity;
 
 use Sulu\Component\Persistence\Repository\RepositoryInterface;
 
+/**
+ * @extends RepositoryInterface<CommentInterface>
+ */
 interface CommentRepositoryInterface extends RepositoryInterface
 {
     /**

--- a/Entity/Thread.php
+++ b/Entity/Thread.php
@@ -47,7 +47,7 @@ class Thread implements ThreadInterface, AuditableInterface
     protected $commentCount = 0;
 
     /**
-     * @var Collection
+     * @var Collection<int, CommentInterface>
      */
     protected $comments;
 
@@ -71,6 +71,9 @@ class Thread implements ThreadInterface, AuditableInterface
      */
     protected $creator;
 
+    /**
+     * @param null|Collection<int, CommentInterface> $comments
+     */
     public function __construct(string $type, string $entityId, Collection $comments = null, int $commentCount = 0)
     {
         $this->type = $type;

--- a/Entity/ThreadInterface.php
+++ b/Entity/ThreadInterface.php
@@ -34,7 +34,7 @@ interface ThreadInterface
     public function setCommentCount(int $commentCount): self;
 
     /**
-     * @return CommentInterface[]|Collection
+     * @return Collection<int, CommentInterface>
      */
     public function getComments(): Collection;
 

--- a/Entity/ThreadRepository.php
+++ b/Entity/ThreadRepository.php
@@ -13,6 +13,9 @@ namespace Sulu\Bundle\CommentBundle\Entity;
 
 use Doctrine\ORM\EntityRepository;
 
+/**
+ * @extends EntityRepository<ThreadInterface>
+ */
 class ThreadRepository extends EntityRepository implements ThreadRepositoryInterface
 {
     public function createNew(string $type, string $entityId): ThreadInterface

--- a/Form/Type/CommentType.php
+++ b/Form/Type/CommentType.php
@@ -31,7 +31,7 @@ class CommentType extends AbstractType
         $this->router = $router;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $attributes = ['threadId' => $options['threadId']];
         if ($options['referrer']) {
@@ -47,7 +47,7 @@ class CommentType extends AbstractType
         $builder->add('submit', SubmitType::class);
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setRequired('threadId');
         $resolver->setDefault('referrer', null);

--- a/SuluCommentBundle.php
+++ b/SuluCommentBundle.php
@@ -27,7 +27,7 @@ class SuluCommentBundle extends Bundle
     /**
      * {@inheritdoc}
      */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $this->buildPersistence(
             [

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "jangregor/phpstan-prophecy": "^1.0",
         "massive/search-bundle": "^2.0.0",
         "php-ffmpeg/php-ffmpeg": "^0.13 || ^0.14",
+        "phpspec/prophecy": "^1.16",
         "phpstan/phpstan": "^1.9",
         "phpstan/phpstan-doctrine": "^1.3",
         "phpstan/phpstan-phpunit": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
         "friendsofphp/php-cs-fixer": "^2.17",
         "handcraftedinthealps/zendsearch": "^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.3.4",
-        "jangregor/phpstan-prophecy": "^0.4.1",
+        "jangregor/phpstan-prophecy": "^1.0",
         "massive/search-bundle": "^2.0.0",
         "php-ffmpeg/php-ffmpeg": "^0.13 || ^0.14",
-        "phpstan/phpstan": "^0.11.12",
-        "phpstan/phpstan-doctrine": "^0.11.5",
-        "phpstan/phpstan-phpunit": "^0.11.2",
-        "phpstan/phpstan-symfony": "^0.11.6",
+        "phpstan/phpstan": "^1.9",
+        "phpstan/phpstan-doctrine": "^1.3",
+        "phpstan/phpstan-phpunit": "^1.3",
+        "phpstan/phpstan-symfony": "^1.2",
         "phpunit/phpunit": "^8.0",
         "symfony/browser-kit": "^4.3",
         "symfony/dotenv": "^4.3",
@@ -32,7 +32,7 @@
         "symfony/monolog-bundle": "^3.1",
         "symfony/security-bundle": "^4.3",
         "symfony/stopwatch": "^4.3",
-        "thecodingmachine/phpstan-strict-rules": "^0.11.2"
+        "thecodingmachine/phpstan-strict-rules": "^1.0"
     },
     "keywords": [],
     "authors": [

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,151 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Parameter \\#2 \\$value of method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\ListBuilderInterface\\:\\:where\\(\\) expects string, array\\|bool\\|float\\|int\\|string given\\.$#"
+			count: 1
+			path: Controller/CommentController.php
+
+		-
+			message: "#^Parameter \\#3 \\$route of class Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\ListRepresentation constructor expects string, mixed given\\.$#"
+			count: 1
+			path: Controller/CommentController.php
+
+		-
+			message: "#^Parameter \\#2 \\$str of function explode expects string, mixed given\\.$#"
+			count: 1
+			path: Controller/ThreadController.php
+
+		-
+			message: "#^Parameter \\#2 \\$value of method Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\ListBuilderInterface\\:\\:where\\(\\) expects string, array\\|bool\\|float\\|int\\|string given\\.$#"
+			count: 1
+			path: Controller/ThreadController.php
+
+		-
+			message: "#^Parameter \\#3 \\$route of class Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\ListRepresentation constructor expects string, mixed given\\.$#"
+			count: 1
+			path: Controller/ThreadController.php
+
+		-
+			message: "#^Method Sulu\\\\Bundle\\\\CommentBundle\\\\Controller\\\\WebsiteCommentController\\:\\:__construct\\(\\) has parameter \\$commentDefaultTemplates with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Controller/WebsiteCommentController.php
+
+		-
+			message: "#^Method Sulu\\\\Bundle\\\\CommentBundle\\\\Controller\\\\WebsiteCommentController\\:\\:__construct\\(\\) has parameter \\$commentSerializationGroups with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Controller/WebsiteCommentController.php
+
+		-
+			message: "#^Method Sulu\\\\Bundle\\\\CommentBundle\\\\Controller\\\\WebsiteCommentController\\:\\:__construct\\(\\) has parameter \\$commentTypes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Controller/WebsiteCommentController.php
+
+		-
+			message: "#^Method Sulu\\\\Bundle\\\\CommentBundle\\\\Controller\\\\WebsiteCommentController\\:\\:view\\(\\) has parameter \\$data with no type specified\\.$#"
+			count: 1
+			path: Controller/WebsiteCommentController.php
+
+		-
+			message: "#^Method Sulu\\\\Bundle\\\\CommentBundle\\\\Controller\\\\WebsiteCommentController\\:\\:view\\(\\) has parameter \\$headers with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Controller/WebsiteCommentController.php
+
+		-
+			message: "#^Method Sulu\\\\Bundle\\\\CommentBundle\\\\Controller\\\\WebsiteCommentController\\:\\:view\\(\\) has parameter \\$statusCode with no type specified\\.$#"
+			count: 1
+			path: Controller/WebsiteCommentController.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of method Sulu\\\\Bundle\\\\CommentBundle\\\\Entity\\\\CommentRepositoryInterface\\:\\:findCommentById\\(\\) expects int, mixed given\\.$#"
+			count: 1
+			path: Controller/WebsiteCommentController.php
+
+		-
+			message: "#^Parameter \\#3 \\$comment of method Sulu\\\\Bundle\\\\CommentBundle\\\\Manager\\\\CommentManagerInterface\\:\\:addComment\\(\\) expects Sulu\\\\Bundle\\\\CommentBundle\\\\Entity\\\\CommentInterface, mixed given\\.$#"
+			count: 1
+			path: Controller/WebsiteCommentController.php
+
+		-
+			message: "#^Parameter \\#3 \\$page of method Sulu\\\\Bundle\\\\CommentBundle\\\\Manager\\\\CommentManagerInterface\\:\\:findPublishedComments\\(\\) expects int, mixed given\\.$#"
+			count: 1
+			path: Controller/WebsiteCommentController.php
+
+		-
+			message: "#^Parameter \\#4 \\$threadTitle of method Sulu\\\\Bundle\\\\CommentBundle\\\\Manager\\\\CommentManagerInterface\\:\\:addComment\\(\\) expects string\\|null, mixed given\\.$#"
+			count: 1
+			path: Controller/WebsiteCommentController.php
+
+		-
+			message: "#^Property Sulu\\\\Bundle\\\\CommentBundle\\\\Controller\\\\WebsiteCommentController\\:\\:\\$commentDefaultTemplates type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Controller/WebsiteCommentController.php
+
+		-
+			message: "#^Property Sulu\\\\Bundle\\\\CommentBundle\\\\Controller\\\\WebsiteCommentController\\:\\:\\$commentSerializationGroups type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Controller/WebsiteCommentController.php
+
+		-
+			message: "#^Property Sulu\\\\Bundle\\\\CommentBundle\\\\Controller\\\\WebsiteCommentController\\:\\:\\$commentTypes type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Controller/WebsiteCommentController.php
+
+		-
+			message: "#^Property Sulu\\\\Bundle\\\\CommentBundle\\\\Entity\\\\Comment\\:\\:\\$message \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: Entity/Comment.php
+
+		-
+			message: "#^Method Sulu\\\\Bundle\\\\CommentBundle\\\\Entity\\\\CommentRepository\\:\\:createNew\\(\\) should return Sulu\\\\Bundle\\\\CommentBundle\\\\Entity\\\\CommentInterface but returns object\\.$#"
+			count: 1
+			path: Entity/CommentRepository.php
+
+		-
+			message: "#^Method Sulu\\\\Bundle\\\\CommentBundle\\\\Entity\\\\CommentRepository\\:\\:findCommentById\\(\\) should return Sulu\\\\Bundle\\\\CommentBundle\\\\Entity\\\\CommentInterface\\|null but returns mixed\\.$#"
+			count: 1
+			path: Entity/CommentRepository.php
+
+		-
+			message: "#^Method Sulu\\\\Bundle\\\\CommentBundle\\\\Entity\\\\CommentRepository\\:\\:findComments\\(\\) should return array\\<Sulu\\\\Bundle\\\\CommentBundle\\\\Entity\\\\CommentInterface\\> but returns mixed\\.$#"
+			count: 1
+			path: Entity/CommentRepository.php
+
+		-
+			message: "#^Method Sulu\\\\Bundle\\\\CommentBundle\\\\Entity\\\\CommentRepository\\:\\:findCommentsByIds\\(\\) should return array\\<Sulu\\\\Bundle\\\\CommentBundle\\\\Entity\\\\CommentInterface\\> but returns mixed\\.$#"
+			count: 1
+			path: Entity/CommentRepository.php
+
+		-
+			message: "#^Method Sulu\\\\Bundle\\\\CommentBundle\\\\Entity\\\\CommentRepository\\:\\:findPublishedComments\\(\\) should return array\\<Sulu\\\\Bundle\\\\CommentBundle\\\\Entity\\\\CommentInterface\\> but returns mixed\\.$#"
+			count: 1
+			path: Entity/CommentRepository.php
+
+		-
+			message: "#^Property Sulu\\\\Bundle\\\\CommentBundle\\\\Entity\\\\Thread\\:\\:\\$changer type mapping mismatch\\: database can contain Sulu\\\\Component\\\\Security\\\\Authentication\\\\UserInterface\\|null but property expects Sulu\\\\Component\\\\Security\\\\Authentication\\\\UserInterface\\.$#"
+			count: 1
+			path: Entity/Thread.php
+
+		-
+			message: "#^Property Sulu\\\\Bundle\\\\CommentBundle\\\\Entity\\\\Thread\\:\\:\\$creator type mapping mismatch\\: database can contain Sulu\\\\Component\\\\Security\\\\Authentication\\\\UserInterface\\|null but property expects Sulu\\\\Component\\\\Security\\\\Authentication\\\\UserInterface\\.$#"
+			count: 1
+			path: Entity/Thread.php
+
+		-
+			message: "#^Property Sulu\\\\Bundle\\\\CommentBundle\\\\Entity\\\\Thread\\:\\:\\$title type mapping mismatch\\: database can contain string\\|null but property expects string\\.$#"
+			count: 1
+			path: Entity/Thread.php
+
+		-
+			message: "#^Call to an undefined method Sulu\\\\Component\\\\Security\\\\Authentication\\\\UserInterface\\:\\:getContact\\(\\)\\.$#"
+			count: 1
+			path: EventSubscriber/CommentSerializationSubscriber.php
+
+		-
+			message: "#^Method Sulu\\\\Bundle\\\\CommentBundle\\\\EventSubscriber\\\\CommentSerializationSubscriber\\:\\:getSubscribedEvents\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: EventSubscriber/CommentSerializationSubscriber.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of function in_array expects array, mixed given\\.$#"
+			count: 1
+			path: EventSubscriber/CommentSerializationSubscriber.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,7 +11,7 @@ parameters:
     paths:
         - .
     level: max
-    excludes_analyse:
+    excludePaths:
         - %currentWorkingDirectory%/DependencyInjection/Configuration.php
         - %currentWorkingDirectory%/Tests/*
         - %currentWorkingDirectory%/vendor/*

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 includes:
-    - vendor/jangregor/phpstan-prophecy/src/extension.neon
+    - vendor/jangregor/phpstan-prophecy/extension.neon
     - vendor/phpstan/phpstan-doctrine/extension.neon
     - vendor/phpstan/phpstan-doctrine/rules.neon
     - vendor/phpstan/phpstan-symfony/extension.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -21,4 +21,4 @@ parameters:
     doctrine:
         objectManagerLoader: Tests/phpstan/object-manager.php
     ignoreErrors:
-        - '#Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch()#'
+        - '#Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\)#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,5 @@
 includes:
+    - phpstan-baseline.neon
     - vendor/jangregor/phpstan-prophecy/extension.neon
     - vendor/phpstan/phpstan-doctrine/extension.neon
     - vendor/phpstan/phpstan-doctrine/rules.neon


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | n/a
| Related issues/PRs | #42
| License | MIT
| Documentation PR | n/a

#### What's in this PR?

I was interested in adding support for PHP8(.2). In preparation of doing that, phpstan can be updated.

I also noticed in the current pipeline that there were 9 errors on PHP 7.4. I first fixed all but one of these (one which I couldn't fix). Then I performed the update of phpstan and all related packages. After the update, a number of extra errors appeared (56).

I tried to fix the relatively low-hanging fruit, but was still left with 30 remaining errors that were put in the baseline.

Many of the errors put in the baseline are related to phpstan-doctrine not being able to infer the resulting type of the query, which causes `Method Sulu\Bundle\CommentBundle\Entity\CommentRepository::findComments() should return array<Sulu\Bundle\CommentBundle\Entity\CommentInterface> but returns mixed.`. The main sulu/sulu also has this for `Sulu\Bundle\CategoryBundle\Entity\CategoryRepository::findCategories()`, as an example.
- https://github.com/phpstan/phpstan-doctrine/issues/308
- https://github.com/phpstan/phpstan-doctrine/issues/221

Another cause is some inconsistencies about fields being nullable or not:
- Entity/Comment.php::$message is a non-nullable property, but the getter does a `??` check. Not a check that feels safe to just remove.
- Entity/Thread.php::$title, $changer, $creator, they are not nullable in code, while they are in the Doctrine mapping.

I would suggest that these can be fixed later?

#### Why?

To add support for PHP 8+