### PR TITLE
remove type from id column in comments/thread list

### DIFF
--- a/Resources/config/lists/comments.xml
+++ b/Resources/config/lists/comments.xml
@@ -34,7 +34,7 @@
     </joins>
 
     <properties>
-        <property name="id" translation="sulu_admin.id" type="integer">
+        <property name="id" translation="sulu_admin.id">
             <field-name>id</field-name>
             <entity-name>%sulu.model.comment.class%</entity-name>
         </property>

--- a/Resources/config/lists/threads.xml
+++ b/Resources/config/lists/threads.xml
@@ -27,7 +27,7 @@
     </joins>
 
     <properties>
-        <property name="id" translation="sulu_admin.id" type="integer">
+        <property name="id" translation="sulu_admin.id">
             <field-name>id</field-name>
             <entity-name>%sulu.model.thread.class%</entity-name>
         </property>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR removes the type from id column.

#### Why?

When displaying this columns the admin breaks.