### PR TITLE
Add possibility to set the thread title

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ Tests/Application/.env.test.local
 # php-cs-fixer
 .php-cs-fixer.cache
 php-cs-fixer
+
+.php-version

--- a/Controller/WebsiteCommentController.php
+++ b/Controller/WebsiteCommentController.php
@@ -127,7 +127,7 @@ class WebsiteCommentController extends AbstractRestController implements ClassRe
         $limit = $request->query->getInt('limit', 10);
         $offset = $request->query->getInt('offset', 0);
 
-        /** @var null|int $pageSize */
+        /** @var int|null $pageSize */
         $pageSize = $request->get('pageSize');
         if ($pageSize) {
             @trigger_deprecation('sulu/comment-bundle', '2.x', 'The usage of the "pageSize" parameter is deprecated.
@@ -170,6 +170,7 @@ class WebsiteCommentController extends AbstractRestController implements ClassRe
                 'data_class' => $this->commentClass,
                 'threadId' => $threadId,
                 'referrer' => $referrer,
+                'threadTitle' => $request->query->get('threadTitle'),
             ]
         );
 
@@ -245,7 +246,7 @@ class WebsiteCommentController extends AbstractRestController implements ClassRe
         /** @var CommentInterface $comment */
         $comment = $this->commentRepository->createNew();
 
-        /** @var null|int $parent */
+        /** @var int|null $parent */
         $parent = $request->get('parent');
         if ($parent) {
             $comment->setParent($this->commentRepository->findCommentById($parent));
@@ -270,7 +271,7 @@ class WebsiteCommentController extends AbstractRestController implements ClassRe
         $comment = $form->getData();
 
         /** @var string $threadTitle */
-        $threadTitle = $request->get('threadTitle');
+        $threadTitle = $request->request->get('threadTitle', '');
         $this->commentManager->addComment($type, $entityId, $comment, $threadTitle);
         $this->entityManager->flush();
 
@@ -330,7 +331,7 @@ class WebsiteCommentController extends AbstractRestController implements ClassRe
     public function deleteCommentAction(string $threadId, string $commentId, Request $request): Response
     {
         /** @var Comment $comment */
-        $comment = $this->commentRepository->findCommentById(\intval($commentId));
+        $comment = $this->commentRepository->findCommentById((int) $commentId);
 
         $this->entityManager->remove($comment);
         $this->entityManager->flush();
@@ -347,8 +348,8 @@ class WebsiteCommentController extends AbstractRestController implements ClassRe
     }
 
     /**
-     * @param null|mixed $data
-     * @param null|string $statusCode
+     * @param mixed|null $data
+     * @param string|null $statusCode
      * @param mixed[] $headers
      *
      * @return View

--- a/Entity/CommentRepository.php
+++ b/Entity/CommentRepository.php
@@ -14,6 +14,9 @@ namespace Sulu\Bundle\CommentBundle\Entity;
 use Doctrine\ORM\NoResultException;
 use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 
+/**
+ * @extends NestedTreeRepository<CommentInterface>
+ */
 class CommentRepository extends NestedTreeRepository implements CommentRepositoryInterface
 {
     public function findComments(string $type, string $entityId, int $limit = 10, int $offset = 0): array

--- a/Form/Type/CommentType.php
+++ b/Form/Type/CommentType.php
@@ -43,13 +43,14 @@ class CommentType extends AbstractType
 
         $builder->setAction($this->router->generate('sulu_comment.post_thread_comments', $attributes));
         $builder->add('message', TextareaType::class);
-        $builder->add('threadTitle', HiddenType::class, ['mapped' => false]);
+        $builder->add('threadTitle', HiddenType::class, ['mapped' => false, 'data' => $options['threadTitle']]);
         $builder->add('submit', SubmitType::class);
     }
 
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setRequired('threadId');
+        $resolver->setDefault('threadTitle', '');
         $resolver->setDefault('referrer', null);
         $resolver->setDefault('parent', null);
         $resolver->setDefault('csrf_protection', false);

--- a/Resources/doc/getting-started.md
+++ b/Resources/doc/getting-started.md
@@ -7,7 +7,8 @@ Following example works for a page:
 ```twig
 {{ render(path('sulu_comment.get_threads_comments', {
     threadId: 'page-' ~ uuid, 
-    referrer: app.request.uri, 
+    referrer: app.request.uri,
+    threadTitle: 'This is my thread title', 
     _format: 'html'
 })) }}
 ```

--- a/Tests/Application/config/templates/pages/overview.xml
+++ b/Tests/Application/config/templates/pages/overview.xml
@@ -5,8 +5,8 @@
 
     <key>overview</key>
 
-    <view>::overview</view>
-    <controller>SuluWebsiteBundle:Default:index</controller>
+    <view>overview</view>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
     <cacheLifetime>2400</cacheLifetime>
 
     <properties>

--- a/Tests/Application/templates/overview.html.twig
+++ b/Tests/Application/templates/overview.html.twig
@@ -1,0 +1,13 @@
+{% extends 'master.html.twig' %}
+
+
+{% block content %}
+
+    {{ render(path('sulu_comment.get_threads_comments', {
+        threadId: 'page-' ~ uuid,
+        referrer: app.request.uri,
+        threadTitle: 'This is my title',
+        _format: 'html'
+    })) }}
+
+{% endblock %}

--- a/Tests/Functional/Controller/WebsiteCommentControllerTest.php
+++ b/Tests/Functional/Controller/WebsiteCommentControllerTest.php
@@ -31,6 +31,7 @@ class WebsiteCommentControllerTest extends SuluTestCase
     {
         $this->client = $this->createAuthenticatedWebsiteClient();
         $this->purgeDatabase();
+        $this->initPhpcr();
     }
 
     public function providePostData()
@@ -290,6 +291,20 @@ class WebsiteCommentControllerTest extends SuluTestCase
         $this->assertEquals('My new Comment', $response[0]['message']);
         $this->assertEquals(CommentInterface::STATE_PUBLISHED, $response[1]['state']);
         $this->assertEquals('Sulu is awesome', $response[1]['message']);
+    }
+
+    public function testGetCommentsHtmlThreadTitle()
+    {
+        $crawler = $this->client->request(
+            'GET',
+            '/'
+        );
+
+        $input = $crawler->filter('input[type="hidden"]');
+
+        $this->assertSame('threadTitle', $input->attr('id'));
+        $this->assertSame('hidden', $input->attr('type'));
+        $this->assertSame('This is my title', $input->attr('value'));
     }
 
     private function postComment(

--- a/Twig/CommentFormFactoryTwigExtension.php
+++ b/Twig/CommentFormFactoryTwigExtension.php
@@ -42,8 +42,12 @@ class CommentFormFactoryTwigExtension extends AbstractExtension
         ];
     }
 
-    public function createCommentForm(string $threadId, ?string $referrer = null, ?int $parent = null): FormView
-    {
+    public function createCommentForm(
+        string $threadId,
+        ?string $referrer = null,
+        ?int $parent = null,
+        ?string $threadTitle = null
+    ): FormView {
         $form = $this->formFactory->create(
             CommentType::class,
             null,
@@ -52,6 +56,7 @@ class CommentFormFactoryTwigExtension extends AbstractExtension
                 'threadId' => $threadId,
                 'referrer' => $referrer,
                 'parent' => $parent,
+                'threadTitle' => $threadTitle,
             ]
         );
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes https://github.com/sulu/SuluCommentBundle/issues/50
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fix for https://github.com/sulu/SuluCommentBundle/issues/50

#### Example Usage

~~~php
    {{ render(path('sulu_comment.get_threads_comments', {
        threadId: 'page-' ~ uuid,
        referrer: app.request.uri,
        threadTitle: 'This is my title',
        _format: 'html'
    })) }}
~~~

#### To Do

- [ ] Create a documentation PR
- [ ] Update tests
